### PR TITLE
Performance Improvement

### DIFF
--- a/src/Calender/Calender.tsx
+++ b/src/Calender/Calender.tsx
@@ -11,19 +11,18 @@ type Props = {
   onDateChange?: (date: Dayjs) => void;
 };
 
-const debug = (list: Dayjs[], ...message: string[]) => {
-  console.log(...message);
-  list.map((d) => {
-    console.log(d.format("YYYY-MM"));
-  });
-  console.log("");
-};
+// const debug = (list: Dayjs[], ...message: string[]) => {
+//   console.log(...message);
+//   list.map((d) => {
+//     console.log(d.format("YYYY-MM"));
+//   });
+//   console.log("");
+// };
 
 /**
  * Calender UI
  * Scrollable calendar UI.
  * Currently, one year from the currently selected date is displayed.
- * @todo Can scroll to infinite.
  * @todo Can render current month when server-side rendering.
  */
 export const Calender: FC<Props> = ({ date = dayjs(), onDateChange }) => {

--- a/src/Calender/Calender.tsx
+++ b/src/Calender/Calender.tsx
@@ -80,7 +80,7 @@ export const Calender: FC<Props> = ({ date = dayjs(), onDateChange }) => {
 
       // debug([...prevYearMonthList, ...nextYearMonthList], "load prev");
 
-      const next = loaded.prev.subtract(1, "year");
+      const next = loaded.next.subtract(1, "year");
       const prev = loaded.prev.subtract(1, "year");
 
       setLoaded({ next, prev });
@@ -106,7 +106,7 @@ export const Calender: FC<Props> = ({ date = dayjs(), onDateChange }) => {
         ref.current.removeEventListener("scroll", handleScrollUp);
       }
     };
-  }, [loaded.next]);
+  }, [loaded.prev]);
 
   useEffect(() => {
     if (ref.current !== null) {
@@ -118,7 +118,7 @@ export const Calender: FC<Props> = ({ date = dayjs(), onDateChange }) => {
         ref.current.removeEventListener("scroll", handleScrollDown);
       }
     };
-  }, [loaded.prev]);
+  }, [loaded.next]);
 
   return (
     <Container>

--- a/src/Calender/Calender.tsx
+++ b/src/Calender/Calender.tsx
@@ -4,10 +4,19 @@ import { FC, useEffect, useMemo, useRef, useState } from "react";
 import { DatePicker } from "../DatePicker";
 import { HEIGHT, MARGIN } from "./constants";
 import { Container } from "./styled";
+import { getNextYearMonthList, getPrevYearMonthList } from "./utils";
 
 type Props = {
   date?: Dayjs;
   onDateChange?: (date: Dayjs) => void;
+};
+
+const debug = (list: Dayjs[], ...message: string[]) => {
+  console.log(...message);
+  list.map((d) => {
+    console.log(d.format("YYYY-MM"));
+  });
+  console.log("");
 };
 
 /**
@@ -22,24 +31,17 @@ export const Calender: FC<Props> = ({ date = dayjs(), onDateChange }) => {
   // This is not the original purpose of memoization, but to fix values.
   const d = useMemo(() => date.clone(), []);
 
-  const nextYearMonthList = Array.from(new Array(12)).map((_, i) =>
-    d.clone().add(i, "month")
-  );
-  const prevYearMonthList = Array.from(new Array(12)).map((_, i) =>
-    d.clone().subtract(12 - i, "month")
-  );
-
   const ref = useRef<HTMLDivElement>(null);
   const [loaded, setLoaded] = useState<{
     prev: Dayjs;
     next: Dayjs;
   }>({
-    prev: d.clone().subtract(12, "month"),
+    prev: d.subtract(12, "month"),
     next: d.add(1, "year"),
   });
   const [monthList, setMonthList] = useState<Dayjs[]>([
-    ...prevYearMonthList,
-    ...nextYearMonthList,
+    ...getPrevYearMonthList(d),
+    ...getNextYearMonthList(d),
   ]);
 
   const vdate = date.clone();
@@ -51,14 +53,17 @@ export const Calender: FC<Props> = ({ date = dayjs(), onDateChange }) => {
 
     const { scrollTop, clientHeight, scrollHeight } = ref.current;
 
-    const next = loaded.next.add(1, "year");
-
     if (scrollTop + clientHeight + MARGIN >= scrollHeight) {
-      const nextYearMonthList = Array.from(new Array(12)).map((_, i) =>
-        loaded.next.clone().add(i, "month")
-      );
-      setLoaded({ next, prev: loaded.prev });
-      setMonthList([...monthList, ...nextYearMonthList]);
+      const prevYearMonthList = getPrevYearMonthList(loaded.next);
+      const nextYearMonthList = getNextYearMonthList(loaded.next);
+
+      // debug([...prevYearMonthList, ...nextYearMonthList], "load next");
+
+      const next = loaded.next.add(1, "year");
+      const prev = loaded.prev.add(1, "year");
+
+      setLoaded({ next, prev });
+      setMonthList([...prevYearMonthList, ...nextYearMonthList]);
     }
   };
 
@@ -69,13 +74,17 @@ export const Calender: FC<Props> = ({ date = dayjs(), onDateChange }) => {
 
     const { scrollTop } = ref.current;
 
-    const prev = loaded.prev.subtract(1, "year");
     if (scrollTop - MARGIN <= 0) {
-      const prevYearMonthList = Array.from(new Array(12)).map((_, i) =>
-        loaded.prev.clone().subtract(12 - i, "month")
-      );
-      setLoaded({ next: loaded.next, prev });
-      setMonthList([...prevYearMonthList, ...monthList]);
+      const prevYearMonthList = getPrevYearMonthList(loaded.prev);
+      const nextYearMonthList = getNextYearMonthList(loaded.prev);
+
+      // debug([...prevYearMonthList, ...nextYearMonthList], "load prev");
+
+      const next = loaded.prev.subtract(1, "year");
+      const prev = loaded.prev.subtract(1, "year");
+
+      setLoaded({ next, prev });
+      setMonthList([...prevYearMonthList, ...nextYearMonthList]);
     }
   };
 
@@ -90,16 +99,26 @@ export const Calender: FC<Props> = ({ date = dayjs(), onDateChange }) => {
   useEffect(() => {
     if (ref.current !== null) {
       ref.current.addEventListener("scroll", handleScrollUp);
-      ref.current.addEventListener("scroll", handleScrollDown);
     }
 
     return () => {
       if (ref.current !== null) {
         ref.current.removeEventListener("scroll", handleScrollUp);
+      }
+    };
+  }, [loaded.next]);
+
+  useEffect(() => {
+    if (ref.current !== null) {
+      ref.current.addEventListener("scroll", handleScrollDown);
+    }
+
+    return () => {
+      if (ref.current !== null) {
         ref.current.removeEventListener("scroll", handleScrollDown);
       }
     };
-  }, [loaded]);
+  }, [loaded.prev]);
 
   return (
     <Container>

--- a/src/Calender/utils.ts
+++ b/src/Calender/utils.ts
@@ -1,0 +1,19 @@
+import { Dayjs } from "dayjs";
+
+/**
+ * This function internally creates a clone of the Dayjs object.
+ * This means that the user of this function will not be aware
+ * of the object's referent.
+ */
+export const getNextYearMonthList = (date: Dayjs) =>
+  Array.from(new Array(12)).map((_, i) => date.clone().add(i, "month"));
+
+/**
+ * This function internally creates a clone of the Dayjs object.
+ * This means that the user of this function will not be aware
+ * of the object's referent.
+ */
+export const getPrevYearMonthList = (date: Dayjs) =>
+  Array.from(new Array(12)).map((_, i) =>
+    date.clone().subtract(12 - i, "month")
+  );


### PR DESCRIPTION
Performance is improved by discarding lists that have been read in the past.
Previously, it kept all loaded lists, but here it stops doing so and always keeps only the most recent two years of lists to speed up re-rendering and event detection.